### PR TITLE
Version upgrade to six-v1.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.15.0" %}
+{% set version = "1.16.0" %}
 
 package:
   name: six
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/six/six-{{ version }}.tar.gz
-  sha256: 30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259
+  sha256: 1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926
 
 build:
   number: 0
@@ -17,6 +17,8 @@ requirements:
   host:
     - python
     - pip
+    - wheel
+    - setuptools
   run:
     - python
 


### PR DESCRIPTION
Category: miniconda
Version change: bump from 1.15.0 to  1.16.0
Changelog: https://github.com/benjaminp/six/blob/master/CHANGES
Upstream Issues: https://github.com/benjaminp/six/issues
Requirements https://github.com/benjaminp/six/blob/master/setup.py
License : https://github.com/benjaminp/six/blob/master/LICENSE
The package builds correctly on concourse.

Actions:

Added/Updated dependencies
-  wheels
-  setuptools

Result:
all succeeded
